### PR TITLE
Add adapt-to-gsd-324.patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+budgie-desktop (10.2.9-2ubuntu2) zesty; urgency=medium
+
+  * Add adapt-to-gsd-324.patch:
+    - Update gnome-session file for gnome-settings-daemon 3.24
+  * debian/control:
+    - Bump minimum gnome-settings-daemon to 3.23.3 for above change
+
+ -- Jeremy Bicha <jbicha@ubuntu.com>  Tue, 07 Feb 2017 16:26:04 -0500
+
 budgie-desktop (10.2.9-2ubuntu1) zesty; urgency=medium
 
   * Bug-fix release (LP: #1653739)

--- a/debian/control
+++ b/debian/control
@@ -86,7 +86,7 @@ Depends:
  ${misc:Depends},
  gnome-session-bin, 
  gnome-session-common, 
- gnome-settings-daemon, 
+ gnome-settings-daemon (>= 3.23.3), 
  gnome-control-center, 
  gnome-menus,
  gnome-screensaver,

--- a/debian/patches/adapt-to-gsd-324.patch
+++ b/debian/patches/adapt-to-gsd-324.patch
@@ -1,0 +1,22 @@
+From 875eded2ffbf8f2a9881a9518964120f6243bb6f Mon Sep 17 00:00:00 2001
+From: Jeremy Bicha <jbicha@ubuntu.com>
+Date: Tue, 7 Feb 2017 16:17:27 -0500
+Subject: [PATCH] Update gnome-session file for gnome-settings-daemon 3.24
+
+---
+ src/session/budgie-desktop.session.in.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/session/budgie-desktop.session.in.in b/src/session/budgie-desktop.session.in.in
+index b448fde..1861c2c 100644
+--- a/src/session/budgie-desktop.session.in.in
++++ b/src/session/budgie-desktop.session.in.in
+@@ -1,4 +1,4 @@
+ [GNOME Session]
+ _Name=Budgie Desktop
+-RequiredComponents=budgie-wm;gnome-settings-daemon;budgie-daemon;budgie-panel;budgie-polkit;
++RequiredComponents=budgie-wm;budgie-daemon;budgie-panel;budgie-polkit;org.gnome.SettingsDaemon.A11yKeyboard;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Clipboard;org.gnome.SettingsDaemon.Color;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Mouse;org.gnome.SettingsDaemon.Orientation;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;org.gnome.SettingsDaemon.XRANDR;org.gnome.SettingsDaemon.XSettings;
+ DesktopName=Budgie Desktop
+-- 
+2.10.2
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 show_nm-applet_in_tray.patch
+adapt-to-gsd-324.patch


### PR DESCRIPTION
Adapted from https://git.gnome.org/browse/gnome-session/commit/?id=18b6e567e1

See https://launchpad.net/bugs/1662647

gnome-settings-daemon 3.23 is available to test in the gnome3-staging PPA

Once you are ok with this change, I can push this transition to zesty.