### PR TITLE
TabSwitcher releases on any modifier, locked modifiers are ignored.

### DIFF
--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -327,7 +327,7 @@ public class TabSwitcher : Object
         mod_timeout = 0;
         Gdk.ModifierType modifier;
         Gdk.Display.get_default().get_default_seat().get_pointer().get_state(Gdk.get_default_root_window(), null, out modifier);
-        if ((modifier & Gdk.ModifierType.MOD1_MASK) == 0 && (modifier & Gdk.ModifierType.MOD4_MASK) == 0) {
+        if ((modifier & Gdk.ModifierType.MODIFIER_MASK ) == 0 || (modifier & Gdk.ModifierType.MODIFIER_MASK ) == 2 ) {
             switcher_window.hide();
             return false;
         }


### PR DESCRIPTION
## Description
This pull request removes hardcoded Alt and Super modifier release check and replaces it with a more generalized Modifier key mask (excludes capslock as it could prevent the Tab Switcher window from disappearing if not ignored).

Should allow for a wider range of modifiers to be used, specifically Ctrl.

This change also allows for Ubuntu Budgie to work with my own project as well https://github.com/rbreaves/kinto, which works with most other major DE's. 

Also discussed https://discourse.ubuntubudgie.org/t/global-menu-is-getting-cut-out/1236/37 with fossfreedom.

This PR is also pending on Solus's budgie-desktop repo, has yet to be reviewed as far as I know.

### Submitter Checklist

- [ x ] Squashed commits with `git rebase -i` (if needed)
- [ x ] Built budgie-desktop and verified that the patch worked (if needed)
