### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 budgie-desktop (10.5.3-6) UNRELEASED; urgency=medium
 
   * Use canonical URL in Vcs-Git.
+  * Remove obsolete fields Contact, Name from debian/upstream/metadata (already
+    present in machine-readable debian/copyright).
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Feb 2022 11:16:43 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ budgie-desktop (10.5.3-6) UNRELEASED; urgency=medium
   * Use canonical URL in Vcs-Git.
   * Remove obsolete fields Contact, Name from debian/upstream/metadata (already
     present in machine-readable debian/copyright).
+  * Update standards version to 4.6.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Feb 2022 11:16:43 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+budgie-desktop (10.5.3-6) UNRELEASED; urgency=medium
+
+  * Use canonical URL in Vcs-Git.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Feb 2022 11:16:43 -0000
+
 budgie-desktop (10.5.3-5) unstable; urgency=medium
 
   * Resolve FTBFS

--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Build-Depends:
  sassc,
  uuid-dev,
  valac (>= 0.48.0),
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0
 Vcs-Browser: https://github.com/UbuntuBudgie/budgie-desktop/tree/debian
 Vcs-Git: https://github.com/UbuntuBudgie/budgie-desktop.git -b debian
 Rules-Requires-Root: no

--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Build-Depends:
  valac (>= 0.48.0),
 Standards-Version: 4.5.1
 Vcs-Browser: https://github.com/UbuntuBudgie/budgie-desktop/tree/debian
-Vcs-Git: https://github.com/UbuntuBudgie/budgie-desktop -b debian
+Vcs-Git: https://github.com/UbuntuBudgie/budgie-desktop.git -b debian
 Rules-Requires-Root: no
 
 Package: budgie-core

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,8 +1,6 @@
 ---
-Name: budgie-desktop
 Bug-Database: https://github.com/solus-project/budgie-desktop
 Cite-As: "Flagship desktop of Solus https://getsol.us/"
-Contact: Josh Strobl <joshua@streambits.io>
 Repository: https://github.com/solus-project/budgie-desktop.git
 Repository-Browse: https://github.com/solus-project/budgie-desktop
 Screenshots: https://getsol.us/solus/experiences/


### PR DESCRIPTION
Fix some issues reported by lintian

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))

* Remove obsolete fields Contact, Name from debian/upstream/metadata (already present in machine-readable debian/copyright).

* Update standards version to 4.6.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/budgie-desktop/2973ffc1-86db-4606-aca6-6bd8cee356f3.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/2973ffc1-86db-4606-aca6-6bd8cee356f3/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/2973ffc1-86db-4606-aca6-6bd8cee356f3/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/2973ffc1-86db-4606-aca6-6bd8cee356f3/diffoscope)).
