### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -114,6 +114,7 @@ Section: doc
 Architecture: all
 Depends: ${misc:Depends}
 Suggests: devhelp
+Multi-Arch: foreign
 Description: documentation files for the budgie-desktop
  Budgie-Desktop is a GTK+ based desktop environment which focuses on
  simplicity and elegance.  It provides a traditional desktop metaphor


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.

Note that in some cases, these multi-arch hints may trigger lintian warnings
until the dependencies of the package support multi-arch. This is expected,
see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.



This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/budgie-desktop/0aab1574-bd0a-4e8c-9ba4-8f604e475746.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)

No differences were encountered between the control files of package \*\*budgie-core\*\*

No differences were encountered between the control files of package \*\*budgie-core-dbgsym\*\*

No differences were encountered between the control files of package \*\*budgie-core-dev\*\*

No differences were encountered between the control files of package \*\*budgie-desktop\*\*
### Control files of package budgie-desktop-doc: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}

No differences were encountered between the control files of package \*\*gir1.2-budgie-1.0\*\*

No differences were encountered between the control files of package \*\*libbudgie-appindexer0\*\*

No differences were encountered between the control files of package \*\*libbudgie-appindexer0-dbgsym\*\*

No differences were encountered between the control files of package \*\*libbudgie-plugin0\*\*

No differences were encountered between the control files of package \*\*libbudgie-plugin0-dbgsym\*\*

No differences were encountered between the control files of package \*\*libbudgie-private0\*\*

No differences were encountered between the control files of package \*\*libbudgie-private0-dbgsym\*\*

No differences were encountered between the control files of package \*\*libbudgietheme0\*\*

No differences were encountered between the control files of package \*\*libbudgietheme0-dbgsym\*\*

No differences were encountered between the control files of package \*\*libraven0\*\*

No differences were encountered between the control files of package \*\*libraven0-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/0aab1574-bd0a-4e8c-9ba4-8f604e475746/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/0aab1574-bd0a-4e8c-9ba4-8f604e475746/diffoscope)).
